### PR TITLE
Remove space in name in `Info.plist`

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Blue Notify</string>
+	<string>BlueNotify</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This PR changes the `CFBundleDisplayName` key from `Blue Notify` to `BlueNotify` (iOS only) to align with the name used [on Bluesky](https://bsky.app/profile/bluenotify.app) and [on the website](https://bluenotify.app/).